### PR TITLE
Replace Safe Eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-virtualized-auto-sizer": "^1.0.4",
     "safe-eval": "^0.4.1",
     "sass": "^1.32.0",
-    "swr": "^0.3.11"
+    "swr": "^0.3.11",
+    "vm2": "^3.9.3"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-number-format": "^4.4.4",
     "react-virtualized": "^9.22.3",
     "react-virtualized-auto-sizer": "^1.0.4",
-    "safe-eval": "^0.4.1",
     "sass": "^1.32.0",
     "swr": "^0.3.11",
     "vm2": "^3.9.3"

--- a/src/lib/thoughtful-fish/findOptions.ts
+++ b/src/lib/thoughtful-fish/findOptions.ts
@@ -1,6 +1,6 @@
-import safeEval from 'safe-eval'
-
 import ameritrade from '../ameritrade'
+
+import safeEval from './safeEval'
 
 export type PresetParams = {
   type: 'CALL' | 'PUT' | 'ALL'

--- a/src/lib/thoughtful-fish/safeEval.ts
+++ b/src/lib/thoughtful-fish/safeEval.ts
@@ -1,0 +1,5 @@
+import { VM } from 'vm2'
+
+export default function safeEval(expression: string, globals: Record<string, unknown>) {
+  return new VM({ sandbox: globals }).run(expression)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3818,6 +3818,11 @@ vm-browserify@1.1.2, vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vm2@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.3.tgz#29917f6cc081cc43a3f580c26c5b553fd3c91f40"
+  integrity sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==
+
 watchpack@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.1.1.tgz#e99630550fca07df9f90a06056987baa40a689c7"


### PR DESCRIPTION
`safe-eval` is vulnerable to sandbox escaping. This pull request replaces it with a secure library.